### PR TITLE
_config.toml: Fix about redirection

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -17,7 +17,7 @@ author = "Harsh Shandilya"
   identifier = "about"
   name = "about"
   title = "About"
-  url = "/"
+  url = "/about"
 
 [[menu.main]]
   identifier = "blog"


### PR DESCRIPTION
Hello @msfjarvis , I visit your blog frequently and today when I visited your blog, I saw a new theme (It is looking nice btw), But when I was going through your blog I found that:

- When clicking on the about logo in the main menu, the site was not redirecting to about page,
 
- This was happening because the about url in the _config.yml was set to '/'

--> Fix that by defining the about page url.

